### PR TITLE
Adding max_values_per_tag

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -43,6 +43,7 @@ class influxdb::params {
   $compact_full_write_cold_duration             = undef
   $max_points_per_block                         = undef
   $max_series_per_database                      = undef
+  $max_values_per_tag                           = undef
 
   $hinted_handoff_enabled                       = true
   $hinted_handoff_dir                           = '/var/lib/influxdb/hh'

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -43,6 +43,7 @@ class influxdb::server (
   $compact_full_write_cold_duration             = $influxdb::params::compact_full_write_cold_duration,
   $max_points_per_block                         = $influxdb::params::max_points_per_block,
   $max_series_per_database                      = $influxdb::params::max_series_per_database,
+  $max_values_per_tag                           = $influxdb::params::max_values_per_tag,
 
   $hinted_handoff_enabled                       = $influxdb::params::hinted_handoff_enabled,
   $hinted_handoff_dir                           = $influxdb::params::hinted_handoff_dir,

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -46,6 +46,7 @@ class influxdb::server::config {
   $compact_full_write_cold_duration             = $influxdb::server::compact_full_write_cold_duration
   $max_points_per_block                         = $influxdb::server::max_points_per_block
   $max_series_per_database                      = $influxdb::server::max_series_per_database
+  $max_values_per_tag                           = $influxdb::params::max_values_per_tag
 
   $hinted_handoff_enabled                       = $influxdb::server::hinted_handoff_enabled
   $hinted_handoff_dir                           = $influxdb::server::hinted_handoff_dir

--- a/templates/influxdb.conf.erb
+++ b/templates/influxdb.conf.erb
@@ -64,7 +64,7 @@ reporting-disabled = <%= @reporting_disabled %>
   max-series-per-database = <%= @max_series_per_database %>
 <% end -%>
 <% if @max_values_per_tag -%>
-  max_values_per_tag = <%= @max_values_per_tag %>
+  max-values-per-tag = <%= @max_values_per_tag %>
 <% end -%>
 
 [hinted-handoff]

--- a/templates/influxdb.conf.erb
+++ b/templates/influxdb.conf.erb
@@ -63,6 +63,9 @@ reporting-disabled = <%= @reporting_disabled %>
 <% if @max_series_per_database -%>
   max-series-per-database = <%= @max_series_per_database %>
 <% end -%>
+<% if @max_values_per_tag -%>
+  max_values_per_tag = <%= @max_values_per_tag %>
+<% end -%>
 
 [hinted-handoff]
   enabled = <%= @hinted_handoff_enabled %>


### PR DESCRIPTION
Needed to fix `InfluxDB Output Error: Response Error: Status Code [400], expected [204], [partial write: max-values-per-tag limit exceeded (100006/100000): measurement="crawler_instagram_hashtags_duplicatesFoundPerHashtag" tag="hashtag" value="sergiofajardo" dr`